### PR TITLE
Replace import hub with import deeplake

### DIFF
--- a/buh/constants.py
+++ b/buh/constants.py
@@ -1,6 +1,6 @@
-import hub
+import deeplake
 
-UNDERSCORED_VERSION = hub.__version__.replace(".", "_")
+UNDERSCORED_VERSION = deeplake.__version__.replace(".", "_")
 
 DATASETS_FOLDER = "datasets"
 

--- a/buh/create_current_version.py
+++ b/buh/create_current_version.py
@@ -1,5 +1,5 @@
 import pytest
-import hub
+import deeplake
 from buh.util import *
 from buh.constants import *
 from buh.tests.common import *
@@ -22,7 +22,7 @@ def _populate_dummy_data(ds):
 
 
 def _create0():
-    ds = hub.Dataset(dataset_path)
+    ds = deeplake.Dataset(dataset_path)
 
     ds.create_tensor(IMAGES, htype="image", sample_compression=COMPRESSION)
     ds.create_tensor(
@@ -32,7 +32,7 @@ def _create0():
 
 
 def _create1():
-    ds = hub.empty(dataset_path, overwrite=True)
+    ds = deeplake.empty(dataset_path, overwrite=True)
     ds.create_tensor(IMAGES, htype="image", sample_compression=COMPRESSION)
     ds.create_tensor(LABELS, htype="class_label", class_names=["class1", "class2"])
     _populate_dummy_data(ds)
@@ -46,7 +46,7 @@ CREATE_FUNCS = {
 
 def _create_dataset_for_current_version():
     # TODO: docstring
-    creator = CREATE_FUNCS.get(hub.__version__, CREATE_FUNCS["default"])
+    creator = CREATE_FUNCS.get(deeplake.__version__, CREATE_FUNCS["default"])
     return creator()
 
 

--- a/buh/tests/common.py
+++ b/buh/tests/common.py
@@ -3,7 +3,7 @@ import shutil
 import pytest
 from buh.util import *
 from buh.constants import *
-import hub
+import deeplake
 
 
 def _(version):
@@ -48,11 +48,11 @@ DATASET_SUFFIX = f"ffw{UNDERSCORED_VERSION}"
 
 # TODO: move these to a separate file
 def _load0(path):
-    return hub.Dataset(path)
+    return deeplake.Dataset(path)
 
 
 def _load1(path):
-    return hub.load(path)
+    return deeplake.load(path)
 
 
 LOAD_FUNCS = {
@@ -62,17 +62,17 @@ LOAD_FUNCS = {
 
 
 def assert_version(required_version):
-    """Asserts that the required version is met by the installation of hub."""
+    """Asserts that the required version is met by the installation of deeplake."""
 
     assert (
-        version_compare(hub.__version__, required_version) >= 0
-    ), f"hub version {hub.__version__} is too old. Required version is {required_version}"
+        version_compare(deeplake.__version__, required_version) >= 0
+    ), f"deeplake version {deeplake.__version__} is too old. Required version is {required_version}"
 
 
 def _bc_load_dataset(path):
     # TODO: docstring/rename func
 
-    loader = LOAD_FUNCS.get(hub.__version__, LOAD_FUNCS["default"])
+    loader = LOAD_FUNCS.get(deeplake.__version__, LOAD_FUNCS["default"])
     return loader(path)
 
 

--- a/buh/tests/test_version.py
+++ b/buh/tests/test_version.py
@@ -1,15 +1,15 @@
 import warnings
-import hub
+import deeplake
 from buh.constants import ALL_VERSIONS, STAGING_HUB_VERSION
 
 
 def test():
-    is_staging = hub.__version__ == STAGING_HUB_VERSION
+    is_staging = deeplake.__version__ == STAGING_HUB_VERSION
     if not is_staging:
         warnings.warn(
-            f"Testing hub backwards compatibility for {hub.__version__}, even though the staging hub version is {STAGING_HUB_VERSION}!"
+            f"Testing deeplake backwards compatibility for {deeplake.__version__}, even though the staging deeplake version is {STAGING_HUB_VERSION}!"
         )
 
     assert (
-        hub.__version__ in ALL_VERSIONS or is_staging
-    ), "When incrementing version string for hub, you must update backwards compatibility tests. IMPORTANT: Make sure when you update `ALL_VERSIONS` you also update the `create_all.sh` script!"
+        deeplake.__version__ in ALL_VERSIONS or is_staging
+    ), "When incrementing version string for deeplake, you must update backwards compatibility tests. IMPORTANT: Make sure when you update `ALL_VERSIONS` you also update the `create_all.sh` script!"

--- a/buh/tests/test_write.py
+++ b/buh/tests/test_write.py
@@ -1,11 +1,11 @@
 import numpy as np
 from .common import *
 from buh.constants import *
-import hub
+import deeplake
 
 
 def assert_new_versions(ds):
-    v = hub.__version__
+    v = deeplake.__version__
 
     img = ds[IMAGES]
     assert img.meta.version == v
@@ -50,7 +50,7 @@ def test_new_tensor(version, request):
     ds.create_tensor("new_tensor")
     ds.new_tensor.extend(get_images()[:10])
 
-    assert ds.meta.version == hub.__version__
+    assert ds.meta.version == deeplake.__version__
 
 
 @versions


### PR DESCRIPTION
Replace import hub with import deeplake since we stopped supporting `import hub`